### PR TITLE
Include only phrases from auto_phrase during segmentation

### DIFF
--- a/src/segment.cpp
+++ b/src/segment.cpp
@@ -40,8 +40,7 @@ void process(const vector<TOTAL_TOKENS_TYPE>& tokens, const vector<POS_ID_TYPE>&
             }
             u = trie[u].children[tokens[k]];
         }
-        quality &= trie[u].id == patterns.size() || 
-                   trie[u].id >= 0 && (
+        quality &= trie[u].id >= 0 && (
                     patterns[trie[u].id].size() > 1 && patterns[trie[u].id].quality >= SEGMENT_MULTI_WORD_QUALITY_THRESHOLD ||
                     patterns[trie[u].id].size() == 1 && patterns[trie[u].id].quality >= SEGMENT_SINGLE_WORD_QUALITY_THRESHOLD
                    );


### PR DESCRIPTION
What is the purpose of 
```c++
trie[u].id == patterns.size()
``` 
in the line this PR is changing?
A side effect of having this line is that during segmentation some phrases that were not included in the result of auto_phrase.sh would be highlighted anyways. An easy way to confirm this problem is by setting SEGMENT_MULTI_WORD_QUALITY_THRESHOLD and SEGMENT_SINGLE_WORD_QUALITY_THRESHOLD to a value higher than 1. The expected result would be to have no phrases segmented but this is not the case. Is my expected behavior wrong or is this indeed a problem?