### PR TITLE
Docker fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+data/corpus.txt
+Python/
+
+*.orig
+*.pyc

--- a/README.md
+++ b/README.md
@@ -115,27 +115,46 @@ The quality of phrases in wiki_quality should be very confident, while wiki_all,
 
 ## Docker
 
-###Default Run
+### Default Run
 
 ```
-sudo docker run -v $PWD/results:/autophrase/results -it \
-    -e FIRST_RUN=1 -e ENABLE_POS_TAGGING=1 \
+sudo docker run -v $PWD/models:/autophrase/models -it \
+    -e ENABLE_POS_TAGGING=1 \
     -e MIN_SUP=30 -e THREAD=10 \
     remenberl/autophrase
 
 ./auto_phrase.sh
 ```
 
-The results will be available in the results folder.
+The results will be available in the ```models``` folder. Note that all of the environment variables above have their default values--leaving the assigments out here would produce exactly the
+same results.
 
-###User Specified Input
+### User Specified Input
+
 Assuming the path to input file is ./data/input.txt.
 ```
-sudo docker run -v $PWD/data:/autophrase/data -v $PWD/results:/autophrase/results -it \
+sudo docker run -v $PWD/data:/autophrase/data -v $PWD/models:/autophrase/models -it \
     -e RAW_TRAIN=data/input.txt \
-    -e FIRST_RUN=1 -e ENABLE_POS_TAGGING=1 \
+    -e ENABLE_POS_TAGGING=1 \
     -e MIN_SUP=30 -e THREAD=10 \
+    -e MODEL=models/MyModel
     remenberl/autophrase
 
 ./auto_phrase.sh
 ```
+
+Note that, in a Docker deployment, the (default) ```data``` and ```models``` directories are renamed to ```default_data``` and ```default_models```, respectively, to avoid conflicts with
+mounted external diretories with the same names. It should be noted as well that there's litle point in saving a model to the default models diretory, since all new files are erased when
+the container is exited (and if an external directory is mounted as "models", and no value is specified for "MODEL", the results will be saved in the "models/DBP" subdirectory). The same 
+wrinkle also means that there's little point to running a container with the "FIRST_RUN" variable set to 0.
+
+Because the original data directory will have been been renamed, it's perfectly fine for the user to mount an external directory called "data" and read the corpus from there--and in most 
+cases, there's no need for a user to change the supplied files stored in the default data directory. If such a change is necessary, though, the environment variable that specifies the
+directory in question is "DATA_DIR".
+
+### In Windows
+
+The ```sudo``` command won't work in a Windows bash shell, and in any case isn't needed in an elevated window--replace it with ```winpty```.
+
+In addition, the ```PWD``` variable works a little oddly in MinGW (the Git bash shell), appending ";C" to the end of the path. To prevent this, replace ```$PWD/models:/autophrase/models``` with ```"/${PWD}/models":/autophrase/models```, and ```$PWD/data/autophrase/data``` with ```"/${PWD}/data:/autophrase/data```.
+

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ sudo docker run -v $PWD/results:/autophrase/results -it \
     -e MIN_SUP=30 -e THREAD=10 \
     remenberl/autophrase
 
-./autophrase.sh
+./auto_phrase.sh
 ```
 
 The results will be available in the results folder.
@@ -137,5 +137,5 @@ sudo docker run -v $PWD/data:/autophrase/data -v $PWD/results:/autophrase/result
     -e MIN_SUP=30 -e THREAD=10 \
     remenberl/autophrase
 
-./autophrase.sh
+./auto_phrase.sh
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,11 @@ RUN \
     echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections  && \
     DEBIAN_FRONTEND=noninteractive  apt-get install -y --force-yes oracle-java8-installer oracle-java8-set-default
 
-RUN \
+# If you have trouble installing Java in the container--or if you need to use OpenJava for licensing reasons--comment out all of the above, 
+# and clone the following container instead:
+# FROM openjdk:8
+
+RUN \   
     echo "===> install g++" && \
     apt-get update && apt-get install -y --force-yes g++
 
@@ -22,18 +26,27 @@ RUN \
     echo "===> install make, curl, perl" && \
     apt-get update && apt-get install -y --force-yes make curl perl
 
-ADD autophrase.tar.gz /
+ARG repo
+ARG branch
+ADD "${repo}/archive/${branch}.zip" /
+RUN \
+    unzip ${branch} && \
+    rm ${branch}.zip && \
+    mv AutoPhrase-${branch} autophrase
 
 RUN \
     echo "===> compile" &&\
-    cd /autophrase && bash compile.sh 
+    cd /autophrase && bash compile.sh &&\
+    chmod 755 tools/treetagger/bin/tree-tagger && \
+    mv data default_data && \
+    mv models default_models
 
 RUN \
     echo "===> clean up..."  && \
     apt-get purge -y --force-yes make && \
     apt-get autoremove -y --purge make && \
     rm -rf /var/cache/oracle-jdk8-installer  && \
-    apt-get clean  && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 ENV COMPILE 0

--- a/docker/make.sh
+++ b/docker/make.sh
@@ -1,7 +1,17 @@
-wget http://github.com/shangjingbo1226/AutoPhrase/archive/master.zip
-unzip master.zip
-rm master.zip
-mv AutoPhrase-master autophrase
-tar -zcvf autophrase.tar.gz autophrase
-rm -r autophrase
-# sudo docker build -t remenberl/autophrase .
+# The only point of this script is to pass the download URL for the AutoPhrase
+# archive file to the Dockerfile--we can create an archive here instead, and
+# pass that in, but in Windows, scripts in such an archive end up with Windows 
+# linefeeds under typical git setings, and won't execute properly in Linux.
+if REPO_URL=$(git remote get-url origin) 2> /dev/null; then
+    REPO=$(echo $REPO_URL | sed "s/\.git//")
+    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+else
+    REPO=https://github.com/shangjingbo1226/AutoPhrase  
+    BRANCH=master
+fi
+
+# In a Windows bash shell, "sudo" won't work.  Note that the shell itself
+# must be elevated, though.
+su 2> /dev/null
+docker build --build-arg repo=$REPO --build-arg branch=$BRANCH \
+    -t remenberl/autophrase .


### PR DESCRIPTION
This PR does the following things:

1. Allows AutoPhrase to run from a Docker container more or less as intended, including an alternate parent (with OpenJava pre-installed) for the container.
2. Allows a Docker container to work under Windows.
3. Allows a Docker container to be created from the current origin and branch, rather than only from the original master.
4. Makes some small changes to the "auto_phrase.sh" so that messages associated with steps not being run (if "FIRST_RUN" is 0) aren't displayed.
5. Updates the section of the README on running from a Docker.