### PR TITLE
Fix issues of running phrasal_segmentation.sh in Docker deployment on Windows with Docker-py.

### DIFF
--- a/auto_phrase.sh
+++ b/auto_phrase.sh
@@ -60,6 +60,7 @@ fi
 ### END Compilation###
 
 TOKENIZER="-cp .:tools/tokenizer/lib/*:tools/tokenizer/resources/:tools/tokenizer/build/ Tokenizer"
+#TOKENIZER="-cp .;tools/tokenizer/lib/*;tools/tokenizer/resources/;tools/tokenizer/build/ Tokenizer"
 TOKEN_MAPPING=tmp/token_mapping.txt
 
 if [ $FIRST_RUN -eq 1 ]; then

--- a/phrasal_segmentation.sh
+++ b/phrasal_segmentation.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # As in "auto_phrase.sh", make the default model amd data directories depend on whether or not we're running
 # from a Docker container.
 if [ -d "default_models" ]; then


### PR DESCRIPTION
"#!/bin/bash" is missing at the top of phrasal_segmentation.sh. Without this statement, Dokcer-py will fail to run this script with the exception "standard_init_linux.go:190: exec user process caused “exec format error”