### PR TITLE
Update auto_phrase.sh

### DIFF
--- a/auto_phrase.sh
+++ b/auto_phrase.sh
@@ -21,7 +21,7 @@ else
 fi
 MODEL=${MODEL:- ${MODELS_DIR}/DBLP}
 # RAW_TRAIN is the input of AutoPhrase, where each line is a single document.
-DEFAULT_TRAIN=${DATA_DIR}/EN/DBLP.5K.txt
+DEFAULT_TRAIN=${DATA_DIR}/EN/DBLP.txt
 RAW_TRAIN=${RAW_TRAIN:- $DEFAULT_TRAIN}
 # When FIRST_RUN is set to 1, AutoPhrase will run all preprocessing. 
 # Otherwise, AutoPhrase directly starts from the current preprocessed data in the tmp/ folder.


### PR DESCRIPTION
The README claims "The default run will download an English corpus from the server of our data mining group" However, the default run defines `DEFAULT_TRAIN=${DATA_DIR}/EN/DBLP.5K.txt`, which already exists in the repo. `DEFAULT_TRAIN` should instead be `DEFAULT_TRAIN=${DATA_DIR}/EN/DBLP.txt` so that DBLP.txt is correctly downloaded in line 56 as intended.