### PR TITLE
Updating Wiki quality extraction script

### DIFF
--- a/tools/wiki_entities/README.md
+++ b/tools/wiki_entities/README.md
@@ -4,7 +4,7 @@ Suppose the language is **X**.
 
 1. Find **X**'s Wikipedia dumps and run [WikipediaEntities](https://github.com/kno10/WikipediaEntities). It will generate a file named "entities". Put it in "**X**/entities". 
 
-2. Put a stop word list of **X** at the "**X**/stopwords".
+2. Put a stop word list of **X** at the "**X**/stopwords.txt".
 
 3. Install some depended python packages.
 ```

--- a/tools/wiki_entities/high_quality_phrase_filter.py
+++ b/tools/wiki_entities/high_quality_phrase_filter.py
@@ -39,11 +39,14 @@ def Load(filename, stopwords, output_filename):
             continue
         tokens = line.strip().split('\t')
         valid = False
-        for token in tokens[2:]:
+        for token in tokens[3:]: # First 3 are name and metadata
             support = int(token.split(':')[-2])
             percentage = float(token.split(':')[-1][:-1])
             if (percentage >= MIN_PERCENT) or (support >= MIN_SUP):
-                name = ':'.join(token.split(':')[:-2])
+
+                # Q2736:Association football:15616:0:84% => Association football
+                name = ':'.join(token.split(':')[1:-3]) 
+
                 valid = True
                 if NoSeparator(name) and StopWordChecking(name, stopwords):
                     candidate.add(name.lower())
@@ -58,7 +61,7 @@ def Load(filename, stopwords, output_filename):
             name = simplify(''.join(name.split()))
             seen.add(name)
         candidate = seen
-    print len(candidate)
+    print(len(candidate))
     for name in candidate:
         out.write(name + '\n')
     out.close()
@@ -80,7 +83,7 @@ def main(argv):
             LANGUAGE = argv[i + 1]
             i += 1
         else:
-            print 'Unknown Parameter =', argv[i]
+            print ('Unknown Parameter =', argv[i])
         i += 1
 
     INPUT_FILENAME = LANGUAGE + '/entities'

--- a/tools/wiki_entities/util.py
+++ b/tools/wiki_entities/util.py
@@ -2,7 +2,7 @@ import codecs
 import re
 from mafan import simplify
 
-p = re.compile('^Q[0-9]+:.*$')
+NEW_VERSION_PREFIX_REGEXP = re.compile('^Q[0-9]+:.*$')
 
 def join_elements(candidate):
     seen = set()
@@ -20,7 +20,7 @@ def write_file(output_filename, phrase_list):
 
 def get_entry_version(token):
     dots_count = token.count(':')
-    has_qid = (p.match(token) != None)
+    has_qid = (NEW_VERSION_PREFIX_REGEXP.match(token) != None)
 
     if (dots_count == 4) and has_qid:
         return "new"

--- a/tools/wiki_entities/util.py
+++ b/tools/wiki_entities/util.py
@@ -1,0 +1,88 @@
+import codecs
+import re
+from mafan import simplify
+
+p = re.compile('^Q[0-9]+:.*$')
+
+def join_elements(candidate):
+    seen = set()
+    for name in candidate:
+        name = simplify(''.join(name.split()))
+        seen.add(name)
+    return seen
+
+def write_file(output_filename, phrase_list):
+    out = codecs.open(output_filename, 'w', 'utf-8')
+    for name in phrase_list:
+        out.write(name + '\n')
+    out.close()
+
+
+def get_entry_version(token):
+    dots_count = token.count(':')
+    has_qid = (p.match(token) != None)
+
+    if (dots_count == 4) and has_qid:
+        return "new"
+    elif (dots_count == 2) and not has_qid:
+        return "old"
+    else:
+        return "undef"
+
+
+def get_document_version(entities_filename):
+    entries_count = {'new': 0, 'old': 0, 'undef': 0}
+
+    MIN_ITERS = 100
+    for i, line in enumerate(codecs.open(entities_filename, 'r', 'utf-8')):
+        tokens = line.strip().split('\t')
+        entries_count[get_entry_version(tokens[-1])] += 1
+
+        if i >= MIN_ITERS:
+            if entries_count['new'] > entries_count['old'] + entries_count['undef']:
+                return "new"
+            elif entries_count['old'] > entries_count['new'] + entries_count['undef']:
+                return "old"
+
+    return "undef" # probably wont happen
+
+
+def get_name_new(entity):
+    return ':'.join(entity.split(':')[1:-3])
+
+
+def get_name_old(entity):
+    return ':'.join(entity.split(':')[:-2])
+
+
+def get_support(entity):
+    return int(entity.split(':')[-2])
+
+
+def get_perc(entity):
+    return float(entity.split(':')[-1][:-1])
+
+
+def iter_entries_new(entities_filename):
+    for line in codecs.open(entities_filename, 'r', 'utf-8'):
+        tokens = line.strip().split('\t')
+        yield (tokens[0], [(get_name_new(x), get_support(x), get_perc(x)) for x in tokens[3:]])
+
+
+def iter_entries_old(entities_filename):
+    for line in codecs.open(entities_filename, 'r', 'utf-8'):
+        tokens = line.strip().split('\t')
+        yield (tokens[0], [(get_name_old(x), get_support(x), get_perc(x)) for x in tokens[2:]])
+
+
+def get_file_loader(entities_filename):
+    version = get_document_version(entities_filename)
+
+    print(f"Version detected: {version}")
+
+    if version == 'new':
+        return iter_entries_new
+    elif version == 'old':
+        return iter_entries_old
+    else:
+        raise Exception

--- a/tools/wiki_entities/wiki_all_phrase_filter.py
+++ b/tools/wiki_entities/wiki_all_phrase_filter.py
@@ -9,20 +9,22 @@ def Load(filename, output_filename):
     candidate = set()
     for line in codecs.open(filename, 'r', 'utf-8'):
         tokens = line.strip().split('\t')
-        for token in tokens[2:]:
-            name = ':'.join(token.split(':')[:-2])
+        for token in tokens[3:]: # First 3 are name and metadata
+            
+            # Q2736:Association football:15616:0:84% => Association football
+            name = ':'.join(token.split(':')[1:-3]) 
 
             if LANGUAGE == 'zh':
                 name = simplify(''.join(name.split()))
             candidate.add(name.lower())
 
         name = tokens[0]
-        name = simplify(''.join(name.split()))
+        name = simplify(' '.join(name.split()))
         if LANGUAGE == 'zh':
             name = simplify(''.join(name.split()))
 
         candidate.add(name.lower())
-    print len(candidate)
+    print(len(candidate))
     
     out = codecs.open(output_filename, 'w', 'utf-8')
     for name in candidate:
@@ -37,7 +39,7 @@ def main(argv):
             LANGUAGE = argv[i + 1]
             i += 1
         else:
-            print 'Unknown Parameter =', argv[i]
+            print('Unknown Parameter =', argv[i])
         i += 1
 
     INPUT_FILENAME = LANGUAGE + '/entities'

--- a/tools/wiki_entities/wiki_all_phrase_filter.py
+++ b/tools/wiki_entities/wiki_all_phrase_filter.py
@@ -1,35 +1,26 @@
 import sys
-import codecs
-from mafan import simplify, split_text
-from textblob import TextBlob
+from mafan import simplify
+from util import *
 
 LANGUAGE = 'en'
 
 def Load(filename, output_filename):
+
+    loader = get_file_loader(filename)
+
     candidate = set()
-    for line in codecs.open(filename, 'r', 'utf-8'):
-        tokens = line.strip().split('\t')
-        for token in tokens[3:]: # First 3 are name and metadata
-            
-            # Q2736:Association football:15616:0:84% => Association football
-            name = ':'.join(token.split(':')[1:-3]) 
+    for line_name, entities in loader(filename):
+        for (ent_name, support, percentage) in entities:
+            candidate.add(ent_name.lower())
 
-            if LANGUAGE == 'zh':
-                name = simplify(''.join(name.split()))
-            candidate.add(name.lower())
-
-        name = tokens[0]
-        name = simplify(' '.join(name.split()))
-        if LANGUAGE == 'zh':
-            name = simplify(''.join(name.split()))
-
-        candidate.add(name.lower())
-    print(len(candidate))
+        line_name = simplify(' '.join(line_name.split()))
+        candidate.add(line_name.lower())
     
-    out = codecs.open(output_filename, 'w', 'utf-8')
-    for name in candidate:
-        out.write(name + '\n')
-    out.close()
+    if LANGUAGE == 'zh':
+        candidate = join_elements(candidate)
+
+    print(len(candidate))
+    write_file(output_filename, candidate)
     
 def main(argv):
     global LANGUAGE


### PR DESCRIPTION
The script for entities extraction was considering the wrong bounds. 

For example,
```
Q2736:Association football:15616:0:84%
```
The script should extract `Association football`. The intervals for such, after spliting with `:` are [1:-3] instead of [0:-2].

Also, the first 3 columns of the `tsv` file are name+metadata. Therefore, `for token in tokens[2:]` had to be replaced by `for token in tokens[3:]`.