### PR TITLE
Solving probable race condition

### DIFF
--- a/tools/tokenizer/src/Tokenizer.java
+++ b/tools/tokenizer/src/Tokenizer.java
@@ -456,9 +456,7 @@ public class Tokenizer {
                             if (punctuation_mapping.containsKey(token)) {
                                 buffer_token.append(punctuation_mapping.get(token));
                             } else {
-                                if (!token2id.containsKey(token)) {
-                                    token2id.put(token, counter.incrementAndGet());
-                                }
+                                token2id.computeIfAbsent(token, k -> counter.incrementAndGet());
                                 buffer_token.append(String.valueOf(token2id.get(token)));
                             }
                         }
@@ -485,9 +483,7 @@ public class Tokenizer {
                                 buffer_token.append(punctuation_mapping.get(lower_token));
                                 buffer_case.append('3');
                             } else {
-                                if (!token2id.containsKey(lower_token)) {
-                                    token2id.put(lower_token, counter.incrementAndGet());
-                                }
+                                token2id.computeIfAbsent(lower_token, k -> counter.incrementAndGet());
                                 buffer_token.append(String.valueOf(token2id.get(lower_token)));
                                 buffer_case.append(((Integer)((all_digit << 2) ^ (all_upper << 1) ^ first_upper)).toString());
                             }


### PR DESCRIPTION
I was getting Floating Point exception when computing the IDF score. One `token_id` didn't appear in any document. Searched this `token_id` in `tokenized_train.txt`. It wasn't there either.

The base `Tokenizer` code had the following in parallel:
```
 if (!token2id.containsKey(token)) {
     token2id.put(token, counter.incrementAndGet());
 }
```
If two threads process the same token that isn't present in the hash table, both can get inside the `if` and the token would be added twice, leaving 1 id unused (the id that  wouldn't appear in any document).

The ConcurrentMap has the `computeIfAbsent` method for checking and adding (if needed) atomically. I am not that confortable with Java, but this seems to do the job.

This probably could also be solved by adding 1 to every `df` in the `documents.h` code.